### PR TITLE
Autocall `install()` if `COLOREDLOGS_AUTOUSE=1`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.cache
+.eggs
+*.egg-info/
+.*.swp
+*.pyc

--- a/coloredlogs.pth
+++ b/coloredlogs.pth
@@ -1,0 +1,1 @@
+import os; exec('try: __import__("coloredlogs").install() if os.environ.get("COLOREDLOGS_AUTOUSE") else None\nexcept ImportError: pass')

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(name='coloredlogs',
       author='Peter Odding',
       author_email='peter@peterodding.com',
       packages=find_packages(),
+      data_files=[('lib/python{}/site-packages'.format(sys.version[:3]),
+                   ['coloredlogs.pth'])],
       entry_points=dict(console_scripts=[
           'coloredlogs = coloredlogs.cli:main',
       ]),


### PR DESCRIPTION
Installs a .pth file so that one can automatically call `install()` by
setting the `COLOREDLOGS_AUTOUSE` environment variable.

Note that due to the order in which `pth` files are loaded, this will not work
if `humanfriendly` is installed system-wide but `colorlogs` installed as a
user package (this is what the `except ImportError` clause catches); however
everything works fine if they are installed to the same site-packages.

See #19.
