### PR TITLE
outside logger should not be changed

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -332,7 +332,6 @@ def install(level=None, **kw):
         formatter_type = ColoredFormatter if use_colors else logging.Formatter
         handler.setFormatter(formatter_type(**formatter_options))
         # Install the stream handler.
-        logger.setLevel(logging.NOTSET)
         logger.addHandler(handler)
 
 


### PR DESCRIPTION
The `install()` function should only install new handlers (and remove old handlers if `reconfigure==True`), verbose level of outside logger should not be changed.
