### PR TITLE
Include docs to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include *.txt
 include coloredlogs.pth
+graft docs


### PR DESCRIPTION
Linux distributions such as Debian use PyPI as the canonical source for packages. This commit adds the Sphinx source to the release tarball so that a corresponding documentation package can be built in addition to the Python ones.