### PR TITLE
Remove usage of deprecated logger.warn function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Here's an example of how easy it is to get started:
    # Some examples.
    logger.debug("this is a debugging message")
    logger.info("this is an informational message")
-   logger.warn("this is a warning message")
+   logger.warning("this is a warning message")
    logger.error("this is an error message")
    logger.critical("this is a critical message")
 


### PR DESCRIPTION
[`logger.warn() is deprecated`](https://docs.python.org/3/library/logging.html#logging.warning), suggest `logger.warning()` in README instead.