### PR TITLE
converter.capture: fix for py3 on darwin by performing ^D check before decoding

### DIFF
--- a/coloredlogs/converter/__init__.py
+++ b/coloredlogs/converter/__init__.py
@@ -92,8 +92,8 @@ def capture(command, encoding='UTF-8'):
             try:
                 command_line = ['script', '-q', temporary_file] + list(command)
                 subprocess.Popen(command_line, stdout=dev_null, stderr=dev_null).wait()
-                with codecs.open(temporary_file, 'r', encoding) as handle:
-                    output = handle.read()
+                with codecs.open(temporary_file, 'rb') as handle:
+                    temporary_file_contents = handle.read()
             finally:
                 os.unlink(temporary_file)
             # On MacOS when standard input is /dev/null I've observed
@@ -110,8 +110,9 @@ def capture(command, encoding='UTF-8'):
             # capture() function shouldn't be bothered with, so we strip it.
             #
             # [1] https://en.wikipedia.org/wiki/End-of-file
-            if output.startswith(b'^D'):
-                output = output[2:]
+            if temporary_file_contents.startswith(b'^D'):
+                temporary_file_contents = temporary_file_contents[2:]
+            output = temporary_file_contents.decode(encoding)
     # Clean up backspace and carriage return characters and the 'erase line'
     # ANSI escape sequence and return the output as a Unicode string.
     return u'\n'.join(clean_terminal_output(output))


### PR DESCRIPTION
Without this, py3 on darwin throws the error:

```
>               if output.startswith(b'^D'):
E               TypeError: startswith first arg must be str or a tuple of str, not bytes

coloredlogs/converter/__init__.py:113: TypeError
```

and the tests fail as a result of this. Figuring this comparison looks like it should still be done on a `bytes` level, I just moved the decoding to after this check.