### PR TITLE
Preserve handler filters if present (allows Filter(s) to work with coloredlogs)

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -434,11 +434,12 @@ def install(level=None, **kw):
                 use_colors = terminal_supports_colors(stream)
         # Create a stream handler.
         # preserve any filters the current handler might have
-        preserved_filters = handler.filters
+        preserved_filters = handler.filters if handler else None
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)
         # and add them back to the new handler
-        handler.filters = preserved_filters
+        if preserved_filters:
+            handler.filters = preserved_filters
         # Prepare the arguments to the formatter, allowing the caller to
         # customize the values of `fmt', `datefmt' and `style' as desired.
         formatter_options = dict(fmt=kw.get('fmt'), datefmt=kw.get('datefmt'))

--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -433,8 +433,10 @@ def install(level=None, **kw):
             if use_colors or use_colors is None:
                 use_colors = terminal_supports_colors(stream)
         # Create a stream handler.
+        preserved_filters = handler.filters # preserve any filters the current handler might have
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)
+        handler.filters = preserved_filters # and add them back to the new handler
         # Prepare the arguments to the formatter, allowing the caller to
         # customize the values of `fmt', `datefmt' and `style' as desired.
         formatter_options = dict(fmt=kw.get('fmt'), datefmt=kw.get('datefmt'))

--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -433,10 +433,12 @@ def install(level=None, **kw):
             if use_colors or use_colors is None:
                 use_colors = terminal_supports_colors(stream)
         # Create a stream handler.
-        preserved_filters = handler.filters # preserve any filters the current handler might have
+        # preserve any filters the current handler might have
+        preserved_filters = handler.filters
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)
-        handler.filters = preserved_filters # and add them back to the new handler
+        # and add them back to the new handler
+        handler.filters = preserved_filters
         # Prepare the arguments to the formatter, allowing the caller to
         # customize the values of `fmt', `datefmt' and `style' as desired.
         formatter_options = dict(fmt=kw.get('fmt'), datefmt=kw.get('datefmt'))


### PR DESCRIPTION
A fix for issue https://github.com/xolox/python-coloredlogs/issues/32 which I've recently encountered myself.
I was able to trace the problem to the way the handlers are replaced, that's when any existing filters get discarded.

The fix is to preserve the existing filters and apply them back once the new handler has been created