### PR TITLE
Default stream for TTY-check is stderr

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -431,7 +431,7 @@ def install(level=None, **kw):
                 use_colors = enable_ansi_support()
             # Disable ANSI escape sequences if 'stream' isn't connected to a terminal.
             if use_colors or use_colors is None:
-                use_colors = terminal_supports_colors(stream)
+                use_colors = terminal_supports_colors(stream or sys.stderr)
         # Create a stream handler.
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)


### PR DESCRIPTION
When checking if output stream is a TTY, use the default stream for logging (stderr)