### PR TITLE
isatty should force usage of the colored formatter

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -425,17 +425,18 @@ def install(level=None, **kw):
                 enable_system_logging(level=syslog_enabled)
         # Figure out whether we can use ANSI escape sequences.
         use_colors = kw.get('isatty', None)
-        isatty = use_colors 
+        force_color = use_colors
         if use_colors or use_colors is None:
             # Try to enable Windows native ANSI support or Colorama.
             if on_windows():
                 use_colors = enable_ansi_support()
             # Disable ANSI escape sequences if 'stream' isn't connected to a terminal.
             if use_colors or use_colors is None:
-                if isatty:
-                  use_colors = True
-                else:  
-                  use_colors = terminal_supports_colors(stream)
+                use_colors = terminal_supports_colors(stream)
+        # isatty should force color, not ask again if the terminal reports back if it is capable
+        # this leads to no color in travis and jupyter !
+        if force_color:
+            use_colors = True
         # Create a stream handler.
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)

--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -425,13 +425,17 @@ def install(level=None, **kw):
                 enable_system_logging(level=syslog_enabled)
         # Figure out whether we can use ANSI escape sequences.
         use_colors = kw.get('isatty', None)
+        isatty = use_colors 
         if use_colors or use_colors is None:
             # Try to enable Windows native ANSI support or Colorama.
             if on_windows():
                 use_colors = enable_ansi_support()
             # Disable ANSI escape sequences if 'stream' isn't connected to a terminal.
             if use_colors or use_colors is None:
-                use_colors = terminal_supports_colors(stream)
+                if isatty:
+                  use_colors = True
+                else:  
+                  use_colors = terminal_supports_colors(stream)
         # Create a stream handler.
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()
         handler.setLevel(level)


### PR DESCRIPTION
some terminals (like travis and jupyter) can not have colored output, because the terminal is checked again with `humanfriendly.terminal_supports_colors(stream)`

this leads to no coloured output on travis and jupyter.

the 'isatty' keyword is triadic : 
```
isatty = None  # autodetect if we can use color
isatty = False  # dont  use color
```
at the Moment You treat `isatty = True` the same way like it would be  `None` - but `isatty=True` should force the use of the `ColoredFormatter` ! 

If You dont like it for a reason, You also can put a new keyword like `force_color` but from my point of view it should not be neccessary.

However, with that patch the colored output is possible now for Jupyter (on stdout) and Travis (on stderr) !

please consider it, until then I need to host my own fork on pypi to get the wheels .... 

yours sincerely

Robert

