### PR TITLE
Added support for multiline inputs.

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -1081,38 +1081,42 @@ class ColoredFormatter(BasicFormatter):
         into the :func:`~logging.Formatter.format()` method of the base
         class.
         """
-        style = self.nn.get(self.level_styles, record.levelname)
-        # After the introduction of the `Empty' class it was reported in issue
-        # 33 that format() can be called when `Empty' has already been garbage
-        # collected. This explains the (otherwise rather out of place) `Empty
-        # is not None' check in the following `if' statement. The reasoning
-        # here is that it's much better to log a message without formatting
-        # then to raise an exception ;-).
-        #
-        # For more details refer to issue 33 on GitHub:
-        # https://github.com/xolox/python-coloredlogs/issues/33
-        if style and Empty is not None:
-            # Due to the way that Python's logging module is structured and
-            # documented the only (IMHO) clean way to customize its behavior is
-            # to change incoming LogRecord objects before they get to the base
-            # formatter. However we don't want to break other formatters and
-            # handlers, so we copy the log record.
+
+        output = ""
+        for line in str(record.msg).splitlines():
+            style = self.nn.get(self.level_styles, record.levelname)
+            # After the introduction of the `Empty' class it was reported in issue
+            # 33 that format() can be called when `Empty' has already been garbage
+            # collected. This explains the (otherwise rather out of place) `Empty
+            # is not None' check in the following `if' statement. The reasoning
+            # here is that it's much better to log a message without formatting
+            # then to raise an exception ;-).
             #
-            # In the past this used copy.copy() but as reported in issue 29
-            # (which is reproducible) this can cause deadlocks. The following
-            # Python voodoo is intended to accomplish the same thing as
-            # copy.copy() without all of the generalization and overhead that
-            # we don't need for our -very limited- use case.
-            #
-            # For more details refer to issue 29 on GitHub:
-            # https://github.com/xolox/python-coloredlogs/issues/29
-            copy = Empty()
-            copy.__class__ = record.__class__
-            copy.__dict__.update(record.__dict__)
-            copy.msg = ansi_wrap(coerce_string(record.msg), **style)
-            record = copy
-        # Delegate the remaining formatting to the base formatter.
-        return logging.Formatter.format(self, record)
+            # For more details refer to issue 33 on GitHub:
+            # https://github.com/xolox/python-coloredlogs/issues/33
+            if style and Empty is not None:
+                # Due to the way that Python's logging module is structured and
+                # documented the only (IMHO) clean way to customize its behavior is
+                # to change incoming LogRecord objects before they get to the base
+                # formatter. However we don't want to break other formatters and
+                # handlers, so we copy the log record.
+                #
+                # In the past this used copy.copy() but as reported in issue 29
+                # (which is reproducible) this can cause deadlocks. The following
+                # Python voodoo is intended to accomplish the same thing as
+                # copy.copy() without all of the generalization and overhead that
+                # we don't need for our -very limited- use case.
+                #
+                # For more details refer to issue 29 on GitHub:
+                # https://github.com/xolox/python-coloredlogs/issues/29
+                copy = Empty()
+                copy.__class__ = record.__class__
+                copy.__dict__.update(record.__dict__)
+                copy.msg = ansi_wrap(coerce_string(line), **style)
+                record = copy
+            # Delegate the remaining formatting to the base formatter.
+            output += super().format(record) + "\n"
+        return output[:-1]
 
 
 class Empty(object):

--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -1081,7 +1081,6 @@ class ColoredFormatter(BasicFormatter):
         into the :func:`~logging.Formatter.format()` method of the base
         class.
         """
-
         output = ""
         for line in str(record.msg).splitlines():
             style = self.nn.get(self.level_styles, record.levelname)

--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -1114,7 +1114,7 @@ class ColoredFormatter(BasicFormatter):
                 copy.msg = ansi_wrap(coerce_string(line), **style)
                 record = copy
             # Delegate the remaining formatting to the base formatter.
-            output += super().format(record) + "\n"
+            output += logging.Formatter.format(self, record) + "\n"
         return output[:-1]
 
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 capturer >= 2.4
 coverage >= 4.2
-pytest >= 3.0.3
+pytest >= 4.6
 pytest-cov >= 2.3.1
 verboselogs >= 1.7


### PR DESCRIPTION
This commit modifies the `format()` method to support multiple lines being formatted.  

Normally, when formatting multiple lines, the first line would be formatted, then the rest would print as if not formatted.

With this modification, it builds a string line-by-line from the input, using the color formatting on each line, then returns the compiled string.

To do this, it is required to cast the input `record.msg` as a string, because it uses the native `splitlines()` method.  This should not be an issue as `logger.Formatter.format()` already converts the input to a string if it isn't already.


Example code:

    import traceback
    import logging
    import coloredlogs
    
    log = logging.getLogger('multilineloggerexample')
    coloredlogs.install(level=logging.DEBUG, logger=log, fmt='[%(levelname)8s] %(message)s')
    
    log.warning('multiline\nerrorgoes\nhereandends\nonthisline')
    log.error(ValueError('value error here\nand ends here'))
    
    try:
        raise ValueError()
    except ValueError:
        log.debug(traceback.format_exc())

Outputs something like this (but with color):

    [ WARNING] multiline
    [ WARNING] errorgoes
    [ WARNING] hereandends
    [ WARNING] onthisline
    [   ERROR] value error here
    [   ERROR] and ends here
    [   DEBUG] Traceback (most recent call last):
    [   DEBUG]   File "main.py", line 12, in <module>
    [   DEBUG]     raise ValueError()
    [   DEBUG] ValueError