### PR TITLE
autodetect ANSI capabilities only if user DOES NOT define use_colors

### DIFF
--- a/coloredlogs/__init__.py
+++ b/coloredlogs/__init__.py
@@ -425,12 +425,12 @@ def install(level=None, **kw):
                 enable_system_logging(level=syslog_enabled)
         # Figure out whether we can use ANSI escape sequences.
         use_colors = kw.get('isatty', None)
-        if use_colors or use_colors is None:
+        if use_colors is None:
             # Try to enable Windows native ANSI support or Colorama.
             if on_windows():
                 use_colors = enable_ansi_support()
             # Disable ANSI escape sequences if 'stream' isn't connected to a terminal.
-            if use_colors or use_colors is None:
+            if use_colors is None:
                 use_colors = terminal_supports_colors(stream)
         # Create a stream handler.
         handler = logging.StreamHandler(stream) if stream else StandardErrorHandler()


### PR DESCRIPTION

If the user defines use_colors, then it does not try to detect terminal capabilities, it just uses it.

This solves some scenarios like logging to consoles that do not report correctly if they support ANSI colors or not. Example: Jenkins, IntelliJ.
If the user wants the to use the autodetect capabilities, then use_colors should be None.