### PR TITLE
Enable use with Python versions 3.9-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.egg-info/
 .*.swp
 *.pyc
+.idea/
+build/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ to `semantic versioning`_.
 .. _Keep a Changelog: http://keepachangelog.com/
 .. _semantic versioning: http://semver.org/
 
+`Release 15.1`_ (2023-04-25)
+----------------------------
+
+Enable use with Python version 3.9 - 3.12: path for site-packages is found via
+sysconfig instead of distutils.
+
 `Release 15.0.1`_ (2021-06-11)
 ------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-humanfriendly >= 9.1
+humanfriendly >= 10.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ Setup script for the `coloredlogs` package.
 
 # Standard library modules.
 import codecs
-import distutils.sysconfig
+import sysconfig
 import os
 import re
 import sys
@@ -81,7 +81,7 @@ def find_pth_directory():
     directory without hard coding its location.
     """
     return ('/' if 'bdist_wheel' in sys.argv
-            else os.path.relpath(distutils.sysconfig.get_python_lib(), sys.prefix))
+            else os.path.relpath(sysconfig.get_path("purelib"), sys.prefix))
 
 
 setup(name='coloredlogs',
@@ -123,6 +123,10 @@ setup(name='coloredlogs',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Topic :: Communications',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy, pypy3
+envlist = py27, py35, py36, py37, py38, py39, p310, py311, py312, pypy, pypy3
 
 [testenv]
 deps = -rrequirements-tests.txt


### PR DESCRIPTION
distutils.sysconfig is deprecated, use sysconfig.get_path("purelib") instead of distutils.sysconfig.get_python_lib() in setup.py